### PR TITLE
Connect to service

### DIFF
--- a/AsyncNetwork/AsyncClient.h
+++ b/AsyncNetwork/AsyncClient.h
@@ -58,6 +58,8 @@
 - (void)start;
 - (void)stop;
 
+- (void)connectToService:(NSNetService *)service;
+
 - (void)sendCommand:(AsyncCommand)command object:(id<NSCoding>)object responseBlock:(AsyncNetworkResponseBlock)block;
 - (void)sendCommand:(AsyncCommand)command object:(id<NSCoding>)object;
 - (void)sendObject:(id<NSCoding>)object;

--- a/AsyncNetwork/AsyncClient.m
+++ b/AsyncNetwork/AsyncClient.m
@@ -105,6 +105,16 @@
 	[self.services removeAllObjects];
 }
 
+- (void)connectToService:(NSNetService *)service
+{
+	// create and configure a connection
+	// the connection takes care of resovling the net service
+	AsyncConnection *connection = [AsyncConnection connectionWithNetService:service];
+	connection.delegate = self;
+	[connection start];
+	[self.connections addObject:connection];
+}
+
 // send object to all servers
 - (void)sendCommand:(AsyncCommand)command object:(id<NSCoding>)object responseBlock:(AsyncNetworkResponseBlock)block;
 {
@@ -145,13 +155,7 @@
 	
 	// connect to the net service
 	if (connect) {
-		
-		// create and configure a connection
-		// the connection takes care of resovling the net service
-		AsyncConnection *connection = [AsyncConnection connectionWithNetService:netService];
-		connection.delegate = self;
-		[connection start];
-		[self.connections addObject:connection];
+		[self connectToService:netService];
 	}	
 }
 


### PR DESCRIPTION
Adds the ability to connect to a specific service discovered by the async client.

This functionality is used when you do not want to auto-connect to any services but rather wait until you have a list of all available before connecting.
